### PR TITLE
Serve /static through the Ingress.

### DIFF
--- a/yaml/ingress.yaml
+++ b/yaml/ingress.yaml
@@ -10,3 +10,7 @@ spec:
         backend:
           serviceName: frontend
           servicePort: 80
+      - path: /static
+        backend:
+          serviceName: frontend
+          servicePort: 80


### PR DESCRIPTION
Required for the Ingress to be able to serve the JS and CSS files.

Without it, the files in /static will throw a 404 error.